### PR TITLE
Display member name in teams at Event Team Page

### DIFF
--- a/app/eventteam.html
+++ b/app/eventteam.html
@@ -120,6 +120,9 @@
                             <md-card-title>
                                 <md-card-title-text>
                                     <span class="md-headline">{{team.name}}</span>
+                                    <md-card-title-text ng-repeat="member in team.teamMembers">
+                                        <span class="md-subhead">{{member.name}}</span>
+                                    </md-card-title-text>
                                 </md-card-title-text>
                             </md-card-title>
                             <md-card-actions layout="row" layout-align="end center">


### PR DESCRIPTION
- Display member name if there is any by using Angular Material style.
- Please reference the event “Event_1” for demonstration.

#110